### PR TITLE
Fix idx markup in logarithm definition

### DIFF
--- a/ptx/section-4-3.xml
+++ b/ptx/section-4-3.xml
@@ -28,7 +28,9 @@
 </p>
 <assemblage><title>Definition of Logarithm</title>
 <p>
-	For <m>b\gt 0, b\ne 1</m>, the <idx><term>base <m>b</m> logarithm of <m>x</m></term></idx>, written <m>\log_{b} x</m>, is the exponent to which <m>b</m> must be raised in order to yield <m>x</m>.
+	For <m>b\gt 0, b\ne 1</m>, the <term>base <m>b</m> logarithm of <m>x</m></term>,
+	<idx>base</idx>
+	written <m>\log_{b} x</m>, is the exponent to which <m>b</m> must be raised in order to yield <m>x</m>.
 </p></assemblage>
 <p>
 	It will help to keep in mind that a logarithm is just an exponent. Some logarithms, like some square roots, are easy to evaluate, while others require a calculator. We will start with the easy ones.


### PR DESCRIPTION
I put "base" inside the idx tag