### PR TITLE
Fix typo in HW 1.3.2

### DIFF
--- a/ptx/section-1-3-exercises.xml
+++ b/ptx/section-1-3-exercises.xml
@@ -35,7 +35,7 @@
     <exercise number="2"><statement><p>
             <ol label="a">
                 <li><p>Find <m>G(-3)</m>, <m>G(-1)</m>, and <m>G(2)</m>.</p></li>
-                <li><p>For what value(s) of <m>s</m> is <m>G(s) = 3?</m>?</p></li>
+                <li><p>For what value(s) of <m>s</m> is <m>G(s) = 3</m>?</p></li>
                 <li><p>Find the intercepts of the graph. List the function values given by the intercepts.</p></li>
                 <li><p>What is the minimum value of <m>G(s)</m>?</p></li>
                 <li><p>For what value(s) of <m>s</m> does <m>G</m> take on its minimum value?</p></li>


### PR DESCRIPTION
The question contains an extra question mark. The rest of the questions seem to place the question mark outside of the PreTeXt formatting, so I did the same.